### PR TITLE
fix: consolidate env vars - remove separate .env.knowledge.local loading

### DIFF
--- a/src/knowledge-platform/infrastructure/supabase-client.test.ts
+++ b/src/knowledge-platform/infrastructure/supabase-client.test.ts
@@ -40,27 +40,24 @@ describe('supabase-client path resolution', () => {
     delete process.env.KNOWLEDGE_DB_SCHEMA;
   });
 
-  it('should resolve .env.knowledge.local path relative to module location, not CWD', async () => {
+  it('should NOT load .env.knowledge.local separately (consolidated env approach)', async () => {
+    // TESTGUARD-APPROVED: TESTGUARD-20250917-297c78c0
+    // Contract realignment after env consolidation refactoring
     // Set up environment variables before import
     process.env.KNOWLEDGE_SUPABASE_URL = 'https://test.supabase.co';
     process.env.KNOWLEDGE_SUPABASE_SERVICE_KEY = 'test-key';
     process.env.KNOWLEDGE_DB_SCHEMA = 'test_schema';
 
-    // Get expected path - should be relative to module location
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    const expectedEnvPath = resolve(join(__dirname, '..', '..', '..', '.env.knowledge.local'));
-
     // Import dotenv mock to check the call
     const dotenv = await import('dotenv');
 
-    // Import the module (will trigger dotenv.config) - using dynamic import after env setup
+    // Import the module - should NOT trigger dotenv.config anymore
+    // Environment variables are now loaded by test setup
     await import('./supabase-client.js');
 
-    // Verify dotenv was called with correct path
-    expect(dotenv.config).toHaveBeenCalledWith({
-      path: expectedEnvPath,
-    });
+    // Verify dotenv was NOT called (env vars should be loaded by test setup)
+    // New contract: supabase-client.ts is NOT responsible for loading env files
+    expect(dotenv.config).not.toHaveBeenCalled();
   });
 
   it('should create supabase client with proper configuration', async () => {

--- a/src/knowledge-platform/infrastructure/supabase-client.ts
+++ b/src/knowledge-platform/infrastructure/supabase-client.ts
@@ -1,25 +1,13 @@
 // Supabase client configuration for Knowledge Platform
 // TECHNICAL-ARCHITECT: Isolated client with connection pooling
-// CONTEXT7_BYPASS: CRITICAL-PATH-FIX - Server fails when run from different CWD
-// Context7: consulted for path - Node.js built-in module for path operations
-// Context7: consulted for url - Node.js built-in module for URL/file path conversion
+// FIX: Consolidated all env vars into main .env file - no separate loading needed
 // Context7: consulted for @supabase/supabase-js - Already in use, maintaining existing pattern
-// Context7: consulted for dotenv - Already in use, maintaining existing pattern
-
-import { resolve, dirname, join } from 'path';
-import { fileURLToPath } from 'url';
 
 import { createClient } from '@supabase/supabase-js';
-import * as dotenv from 'dotenv';
 
-// Get the directory of this module file to make path resolution CWD-independent
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// Load Knowledge Platform specific environment - relative to project root
-// Goes up 3 levels from src/knowledge-platform/infrastructure/ to project root
-const envPath = join(__dirname, '..', '..', '..', '.env.knowledge.local');
-dotenv.config({ path: resolve(envPath) });
+// Environment variables should already be loaded by the main process
+// The MCP server uses --env-file flag to load the main .env file
+// No need to load a separate .env.knowledge.local file
 
 // Validate required environment variables
 const requiredEnvVars = [

--- a/test/setup-integration-env.ts
+++ b/test/setup-integration-env.ts
@@ -1,0 +1,32 @@
+// Integration test environment setup
+// Critical-Engineer: consulted for test environment configuration and mocking strategy
+// Context7: consulted for dotenv
+// Context7: consulted for path
+
+// Load environment variables for integration tests that need real connections
+import { config } from 'dotenv';
+import path from 'path';
+
+// Determine which env file to load based on environment
+const envFile = process.env.CI ? '.env.ci' : '.env';
+const envPath = path.resolve(process.cwd(), envFile);
+
+// Load the environment file
+config({ path: envPath });
+
+// Verify critical environment variables are loaded for integration tests
+const requiredVars = [
+  'KNOWLEDGE_SUPABASE_URL',
+  'KNOWLEDGE_SUPABASE_SERVICE_KEY',
+  'KNOWLEDGE_DB_SCHEMA'
+];
+
+// In CI, these might be dummy values, which is OK for build validation
+// In local dev, these should be real values for integration testing
+for (const varName of requiredVars) {
+  if (!process.env[varName]) {
+    console.warn(`Warning: Missing environment variable ${varName} for integration tests`);
+  }
+}
+
+console.log(`Integration test environment loaded from: ${envPath}`);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    // Load environment variables for tests
+    setupFiles: ['./test/setup-integration-env.ts'],
     // TESTGUARD ENFORCEMENT: Explicit test inclusion/exclusion
     // Only run TypeScript source files, never compiled JS
     include: [


### PR DESCRIPTION
- Simplified supabase-client.ts to use main .env file
- Removed unnecessary path resolution imports
- Server now uses --env-file flag for all env vars
- Add KNOWLEDGE_* vars to main .env file (not committed)

Fixes MCP server startup issues from missing environment variables.